### PR TITLE
Add `Integer` transformer and remove `mdb_init` calling

### DIFF
--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -11,7 +11,7 @@ cdef extern from "glib.h":
         pass
 
 cdef extern from "mdbsql.h":
-    void mdb_init()
+    # void mdb_init()
     ctypedef struct MdbHandle:
         int num_catalog
         GPtrArray* catalog
@@ -60,7 +60,7 @@ cdef class MDB(object):
     cdef MdbHandle* _handle
 
     def __init__(self, path):
-        mdb_init()
+        # mdb_init()
         self._handle = mdb_open(path, MDB_NOFLAGS)
         if not mdb_read_catalog(self._handle, MDB_ANY):
             raise Exception("File is not a valid Access database!")

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -11,7 +11,6 @@ cdef extern from "glib.h":
         pass
 
 cdef extern from "mdbsql.h":
-    # void mdb_init()
     ctypedef struct MdbHandle:
         int num_catalog
         GPtrArray* catalog
@@ -61,7 +60,6 @@ cdef class MDB(object):
     cdef MdbHandle* _handle
 
     def __init__(self, path):
-        # mdb_init()
         self._handle = mdb_open(path, MDB_NOFLAGS)
         if not mdb_read_catalog(self._handle, MDB_ANY):
             raise Exception("File is not a valid Access database!")

--- a/mdbread.pyx
+++ b/mdbread.pyx
@@ -48,6 +48,7 @@ cdef extern from "mdbsql.h":
     void mdb_exit()
 
 transformers = {
+    "Integer": lambda x: int(x) if x != "" else "",
     "Long Integer": lambda x: int(x) if x != "" else "",
     "Single": float,
     "Boolean": lambda x: bool(int(x)),


### PR DESCRIPTION
Changes:
1. Add `Integer` transformer.
2. Remove `mdb_init` calling. In mdbtools-0.7.1, `mdb_init` is deprecated and doing nothing, [source code](https://github.com/brianb/mdbtools/blob/master/src/libmdb/mem.c).

Thank you for this nice tool.